### PR TITLE
fix usage of idiomatic react props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ var mq = React.createClass({
     if (props.query) {
       this.query = props.query;
     } else {
-      this.query = toQuery(omit(props, excludedQueryKeys));
+      this.query = toQuery(props);
     }
 
     if (!this.query) {

--- a/src/index.js
+++ b/src/index.js
@@ -18,8 +18,7 @@ var excludedQueryKeys = Object.keys(defaultTypes);
 var excludedPropKeys = excludedQueryKeys.concat(mediaKeys);
 
 var mq = React.createClass({
-  displayName: 'MediaQuery',
-  propTypes: types,
+  displayName: 'MediaQuery'
 
   getDefaultProps: function(){
     return {

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ var defaultTypes = {
 };
 var mediaKeys = Object.keys(mediaQuery.all);
 var types = assign(defaultTypes, mediaQuery.all);
-var excludedQueryKeys = Object.keys(types);
+var excludedQueryKeys = Object.keys(defaultTypes);
 var excludedPropKeys = excludedQueryKeys.concat(mediaKeys);
 
 var mq = React.createClass({
@@ -46,7 +46,7 @@ var mq = React.createClass({
     if (props.query) {
       this.query = props.query;
     } else {
-      this.query = toQuery(props);
+      this.query = toQuery(omit(props, excludedQueryKeys));
     }
 
     if (!this.query) {

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,6 @@ var defaultTypes = {
   query: React.PropTypes.string
 };
 var mediaKeys = Object.keys(mediaQuery.all);
-var types = assign(defaultTypes, mediaQuery.all);
 var excludedQueryKeys = Object.keys(defaultTypes);
 var excludedPropKeys = excludedQueryKeys.concat(mediaKeys);
 


### PR DESCRIPTION
I think line 49 `this.query = toQuery(omit(props, excludedQueryKeys));` was excluding the idiomatic props from being used in `toQuery`. I was getting `Invalid or missing MediaQuery!` when not using the query string.