### PR TITLE
switch to matchmedia module for client/server abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,39 +21,39 @@ This module is pretty straightforward: You specify a set of requirements, and th
 
 ## Usage
 
-A mq element functions like any other React component, which means you can nest them and do all the normal jazz.
+A Mq element functions like any other React component, which means you can nest them and do all the normal jazz.
 
 ### Using CSS Media Queries
 
-```js
-var mq = require('react-responsive');
+```jsx
+var Mq = require('react-responsive');
 
 var A = React.createClass({
   render: function(){
     return (
       <div>
         <div>Device Test!</div>
-        <mq query='(min-device-width: 1224px)'>
+        <Mq query='(min-device-width: 1224px)'>
           <div>You are a desktop or laptop</div>
-          <mq query='(min-device-width: 1824px)'>
+          <Mq query='(min-device-width: 1824px)'>
             <div>You also have a huge screen</div>
-          </mq>
-          <mq query='(max-width: 1224px)'>
+          </Mq>
+          <Mq query='(max-width: 1224px)'>
             <div>You are sized like a tablet or mobile phone though</div>
-          </mq>
-        </mq>
-        <mq query='(max-device-width: 1224px)'>
+          </Mq>
+        </Mq>
+        <Mq query='(max-device-width: 1224px)'>
           <div>You are a tablet or mobile phone</div>
-        </mq>
-        <mq query='(orientation: portrait)'>
+        </Mq>
+        <Mq query='(orientation: portrait)'>
           <div>You are portrait</div>
-        </mq>
-         <mq query='(orientation: landscape)'>
+        </Mq>
+         <Mq query='(orientation: landscape)'>
           <div>You are landscape</div>
-        </mq>
-        <mq query='(min-resolution: 2dppx)'>
+        </Mq>
+        <Mq query='(min-resolution: 2dppx)'>
           <div>You are retina</div>
-        </mq>
+        </Mq>
       </div>
     );
   }
@@ -71,35 +71,78 @@ For a list of all possible shorthands and value types see https://github.com/wea
 Any numbers given as a shorthand will be expanded to px (`1234` will become `'1234px'`)
 
 
-```js
-var mq = require('react-responsive');
+```jsx
+var Mq = require('react-responsive');
 
 var A = React.createClass({
   render: function(){
     return (
       <div>
         <div>Device Test!</div>
-        <mq minDeviceWidth={1224}>
+        <Mq minDeviceWidth={1224}>
           <div>You are a desktop or laptop</div>
-          <mq minDeviceWidth={1824}>
+          <Mq minDeviceWidth={1824}>
             <div>You also have a huge screen</div>
-          </mq>
-          <mq maxWidth={1224}>
+          </Mq>
+          <Mq maxWidth={1224}>
             <div>You are sized like a tablet or mobile phone though</div>
-          </mq>
-        </mq>
-        <mq maxDeviceWidth={1224}>
+          </Mq>
+        </Mq>
+        <Mq maxDeviceWidth={1224}>
           <div>You are a tablet or mobile phone</div>
-        </mq>
-        <mq orientation='portrait'>
+        </Mq>
+        <Mq orientation='portrait'>
           <div>You are portrait</div>
-        </mq>
-         <mq orientation='landscape'>
+        </Mq>
+         <Mq orientation='landscape'>
           <div>You are landscape</div>
-        </mq>
-        <mq minResolution='2dppx'>
+        </Mq>
+        <Mq minResolution='2dppx'>
           <div>You are retina</div>
-        </mq>
+        </Mq>
+      </div>
+    );
+  }
+});
+```
+
+### Server rendering
+
+Server rendering can be done by passing static values through the `values` property.
+
+The values property can contain `orientation`, `scan`, `aspectRatio`, `deviceAspectRatio`,
+`height`, `deviceHeight`, `width`, `deviceWidth`, `color`, `colorIndex`, `monochrome`,
+and `resolution` to be matched against the media query.
+
+```jsx
+var Mq = require('react-responsive');
+
+var A = React.createClass({
+  render: function(){
+    return (
+      <div>
+        <div>Device Test!</div>
+        <Mq minDeviceWidth={1224} values={{deviceWidth: 1600}}>
+          <div>You are a desktop or laptop</div>
+          <Mq minDeviceWidth={1824}>
+            <div>You also have a huge screen</div>
+          </Mq>
+          <Mq maxWidth={1224}>
+            <div>You are sized like a tablet or mobile phone though</div>
+          </Mq>
+        </Mq>
+        <Mq maxDeviceWidth={1224}>
+          <div>You are a tablet or mobile phone</div>
+        </Mq>
+        <Mq orientation='portrait'>
+          <div>You are portrait</div>
+        </Mq>
+         <Mq orientation='landscape'>
+          <div>You are landscape</div>
+        </Mq>
+        <Mq minResolution='2dppx'>
+          <div>You are retina</div>
+        </Mq>
       </div>
     );
   }

--- a/README.md
+++ b/README.md
@@ -21,39 +21,39 @@ This module is pretty straightforward: You specify a set of requirements, and th
 
 ## Usage
 
-A Mq element functions like any other React component, which means you can nest them and do all the normal jazz.
+A MediaQuery element functions like any other React component, which means you can nest them and do all the normal jazz.
 
 ### Using CSS Media Queries
 
 ```jsx
-var Mq = require('react-responsive');
+var MediaQuery = require('react-responsive');
 
 var A = React.createClass({
   render: function(){
     return (
       <div>
         <div>Device Test!</div>
-        <Mq query='(min-device-width: 1224px)'>
+        <MediaQuery query='(min-device-width: 1224px)'>
           <div>You are a desktop or laptop</div>
-          <Mq query='(min-device-width: 1824px)'>
+          <MediaQuery query='(min-device-width: 1824px)'>
             <div>You also have a huge screen</div>
-          </Mq>
-          <Mq query='(max-width: 1224px)'>
+          </MediaQuery>
+          <MediaQuery query='(max-width: 1224px)'>
             <div>You are sized like a tablet or mobile phone though</div>
-          </Mq>
-        </Mq>
-        <Mq query='(max-device-width: 1224px)'>
+          </MediaQuery>
+        </MediaQuery>
+        <MediaQuery query='(max-device-width: 1224px)'>
           <div>You are a tablet or mobile phone</div>
-        </Mq>
-        <Mq query='(orientation: portrait)'>
+        </MediaQuery>
+        <MediaQuery query='(orientation: portrait)'>
           <div>You are portrait</div>
-        </Mq>
-         <Mq query='(orientation: landscape)'>
+        </MediaQuery>
+         <MediaQuery query='(orientation: landscape)'>
           <div>You are landscape</div>
-        </Mq>
-        <Mq query='(min-resolution: 2dppx)'>
+        </MediaQuery>
+        <MediaQuery query='(min-resolution: 2dppx)'>
           <div>You are retina</div>
-        </Mq>
+        </MediaQuery>
       </div>
     );
   }
@@ -72,34 +72,34 @@ Any numbers given as a shorthand will be expanded to px (`1234` will become `'12
 
 
 ```jsx
-var Mq = require('react-responsive');
+var MediaQuery = require('react-responsive');
 
 var A = React.createClass({
   render: function(){
     return (
       <div>
         <div>Device Test!</div>
-        <Mq minDeviceWidth={1224}>
+        <MediaQuery minDeviceWidth={1224}>
           <div>You are a desktop or laptop</div>
-          <Mq minDeviceWidth={1824}>
+          <MediaQuery minDeviceWidth={1824}>
             <div>You also have a huge screen</div>
-          </Mq>
-          <Mq maxWidth={1224}>
+          </MediaQuery>
+          <MediaQuery maxWidth={1224}>
             <div>You are sized like a tablet or mobile phone though</div>
-          </Mq>
-        </Mq>
-        <Mq maxDeviceWidth={1224}>
+          </MediaQuery>
+        </MediaQuery>
+        <MediaQuery maxDeviceWidth={1224}>
           <div>You are a tablet or mobile phone</div>
-        </Mq>
-        <Mq orientation='portrait'>
+        </MediaQuery>
+        <MediaQuery orientation='portrait'>
           <div>You are portrait</div>
-        </Mq>
-         <Mq orientation='landscape'>
+        </MediaQuery>
+         <MediaQuery orientation='landscape'>
           <div>You are landscape</div>
-        </Mq>
-        <Mq minResolution='2dppx'>
+        </MediaQuery>
+        <MediaQuery minResolution='2dppx'>
           <div>You are retina</div>
-        </Mq>
+        </MediaQuery>
       </div>
     );
   }
@@ -112,37 +112,40 @@ Server rendering can be done by passing static values through the `values` prope
 
 The values property can contain `orientation`, `scan`, `aspectRatio`, `deviceAspectRatio`,
 `height`, `deviceHeight`, `width`, `deviceWidth`, `color`, `colorIndex`, `monochrome`,
-and `resolution` to be matched against the media query.
+ `resolution` and `type` to be matched against the media query.
+
+`type` can be one of: `all`, `grid`, `aural`, `braille`, `handheld`, `print`, `projection`,
+`screen`, `tty`, `tv` or `embossed`.
 
 ```jsx
-var Mq = require('react-responsive');
+var MediaQuery = require('react-responsive');
 
 var A = React.createClass({
   render: function(){
     return (
       <div>
         <div>Device Test!</div>
-        <Mq minDeviceWidth={1224} values={{deviceWidth: 1600}}>
+        <MediaQuery minDeviceWidth={1224} values={{deviceWidth: 1600}}>
           <div>You are a desktop or laptop</div>
-          <Mq minDeviceWidth={1824}>
+          <MediaQuery minDeviceWidth={1824}>
             <div>You also have a huge screen</div>
-          </Mq>
-          <Mq maxWidth={1224}>
+          </MediaQuery>
+          <MediaQuery maxWidth={1224}>
             <div>You are sized like a tablet or mobile phone though</div>
-          </Mq>
-        </Mq>
-        <Mq maxDeviceWidth={1224}>
+          </MediaQuery>
+        </MediaQuery>
+        <MediaQuery maxDeviceWidth={1224}>
           <div>You are a tablet or mobile phone</div>
-        </Mq>
-        <Mq orientation='portrait'>
+        </MediaQuery>
+        <MediaQuery orientation='portrait'>
           <div>You are portrait</div>
-        </Mq>
-         <Mq orientation='landscape'>
+        </MediaQuery>
+         <MediaQuery orientation='landscape'>
           <div>You are landscape</div>
-        </Mq>
-        <Mq minResolution='2dppx'>
+        </MediaQuery>
+        <MediaQuery minResolution='2dppx'>
           <div>You are retina</div>
-        </Mq>
+        </MediaQuery>
       </div>
     );
   }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "dependencies": {
     "lodash.omit": "^3.0.0",
+    "matchmedia": "^0.1.1",
     "object-assign": "^2.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "jshint-stylish": "^0.4.0",
     "merge-stream": "^0.1.5",
     "mocha": "^1.20.1",
-    "reactify": "^0.14.0",
+    "reactify": "^1.0.0",
     "should": "^4.0.4",
     "vinyl-buffer": "0.0.0",
     "vinyl-source-stream": "^0.1.1",

--- a/samples/sandbox/src/index.jsx
+++ b/samples/sandbox/src/index.jsx
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var Mq = require('../../../src');
+var MediaQuery = require('../../../src');
 var React = require('react');
 window.React = React; // for dev
 
@@ -12,28 +12,28 @@ var App = React.createClass({
     return (
       <div>
         <div>Device Test!</div>
-        <Mq minDeviceWidth={1224}>
+        <MediaQuery minDeviceWidth={1224}>
           <div>You are a desktop or laptop</div>
-          <Mq minDeviceWidth={1824}>
+          <MediaQuery minDeviceWidth={1824}>
             <div>You also have a huge screen</div>
-          </Mq>
-          <Mq maxWidth={1224}>
+          </MediaQuery>
+          <MediaQuery maxWidth={1224}>
             <div>You are sized like a tablet or mobile phone though</div>
-          </Mq>
-        </Mq>
-        <Mq maxDeviceWidth={1224}>
+          </MediaQuery>
+        </MediaQuery>
+        <MediaQuery maxDeviceWidth={1224}>
           <div>You are a tablet or mobile phone</div>
-        </Mq>
+        </MediaQuery>
 
-        <Mq orientation='portrait'>
+        <MediaQuery orientation='portrait'>
           <div>You are portrait</div>
-        </Mq>
-         <Mq orientation='landscape'>
+        </MediaQuery>
+         <MediaQuery orientation='landscape'>
           <div>You are landscape</div>
-        </Mq>
-        <Mq minResolution='2dppx'>
+        </MediaQuery>
+        <MediaQuery minResolution='2dppx'>
           <div>You are retina</div>
-        </Mq>
+        </MediaQuery>
       </div>
     );
   }

--- a/samples/static/src/index.jsx
+++ b/samples/static/src/index.jsx
@@ -1,6 +1,6 @@
 'use strict';
 
-var Mq = require('../../../src');
+var MediaQuery = require('../../../src');
 var React = require('react');
 
 var App = React.createClass({
@@ -9,28 +9,28 @@ var App = React.createClass({
     return (
       <div>
         <div>Device Test!</div>
-        <Mq minDeviceWidth={1224} values={{deviceWidth: 1230}}>
+        <MediaQuery minDeviceWidth={1224} values={{deviceWidth: 1230}}>
           <div>You are a desktop or laptop</div>
-          <Mq minDeviceWidth={1824}>
+          <MediaQuery minDeviceWidth={1824}>
             <div>You also have a huge screen</div>
-          </Mq>
-          <Mq maxWidth={1224}>
+          </MediaQuery>
+          <MediaQuery maxWidth={1224}>
             <div>You are sized like a tablet or mobile phone though</div>
-          </Mq>
-        </Mq>
-        <Mq maxDeviceWidth={1224}>
+          </MediaQuery>
+        </MediaQuery>
+        <MediaQuery maxDeviceWidth={1224}>
           <div>You are a tablet or mobile phone</div>
-        </Mq>
+        </MediaQuery>
 
-        <Mq orientation='portrait'>
+        <MediaQuery orientation='portrait'>
           <div>You are portrait</div>
-        </Mq>
-         <Mq orientation='landscape'>
+        </MediaQuery>
+         <MediaQuery orientation='landscape'>
           <div>You are landscape</div>
-        </Mq>
-        <Mq minResolution='2dppx'>
+        </MediaQuery>
+        <MediaQuery minResolution='2dppx'>
           <div>You are retina</div>
-        </Mq>
+        </MediaQuery>
       </div>
     );
   }

--- a/samples/static/src/index.jsx
+++ b/samples/static/src/index.jsx
@@ -1,10 +1,7 @@
-/* global document, window */
-
 'use strict';
 
 var Mq = require('../../../src');
 var React = require('react');
-window.React = React; // for dev
 
 var App = React.createClass({
   displayName: 'demo',
@@ -12,7 +9,7 @@ var App = React.createClass({
     return (
       <div>
         <div>Device Test!</div>
-        <Mq minDeviceWidth={1224}>
+        <Mq minDeviceWidth={1224} values={{deviceWidth: 1230}}>
           <div>You are a desktop or laptop</div>
           <Mq minDeviceWidth={1824}>
             <div>You also have a huge screen</div>
@@ -39,4 +36,4 @@ var App = React.createClass({
   }
 });
 
-React.renderComponent(App(), document.body);
+console.log(React.renderToString(<App />));

--- a/src/index.js
+++ b/src/index.js
@@ -6,11 +6,12 @@ var React = require('react');
 var omit = require('lodash.omit');
 var mediaQuery = require('./mediaQuery');
 var toQuery = require('./toQuery');
-var matchMedia = typeof window !== 'undefined' ? window.matchMedia : null;
+var matchMedia = require('matchmedia');
 
 var defaultTypes = {
   component: React.PropTypes.func,
-  query: React.PropTypes.string
+  query: React.PropTypes.string,
+  values: React.PropTypes.object
 };
 var mediaKeys = Object.keys(mediaQuery.all);
 var excludedQueryKeys = Object.keys(defaultTypes);
@@ -49,7 +50,7 @@ var mq = React.createClass({
     if (!this.query) {
       throw new Error('Invalid or missing MediaQuery!');
     }
-    this._mql = matchMedia(this.query);
+    this._mql = matchMedia(this.query, this.props.values);
     this._mql.addListener(this.updateMatches);
     this.updateMatches();
   },

--- a/src/mediaQuery.js
+++ b/src/mediaQuery.js
@@ -69,6 +69,7 @@ assign(features, matchers);
 
 // media types
 var types = {
+  all: PropTypes.bool,
   grid: PropTypes.bool,
   aural: PropTypes.bool,
   braille: PropTypes.bool,

--- a/src/mediaQuery.js
+++ b/src/mediaQuery.js
@@ -85,6 +85,9 @@ var all = {};
 assign(all, types);
 assign(all, features);
 
+// add the type property
+assign(matchers, { type: Object.keys(types) });
+
 module.exports = {
   all: all,
   types: types,

--- a/src/mediaQuery.js
+++ b/src/mediaQuery.js
@@ -6,8 +6,8 @@ var stringOrNumber = PropTypes.oneOfType([
   PropTypes.number
 ]);
 
-var features = {
-  // media features
+// properties that match media queries
+var matchers = {
   orientation: PropTypes.oneOf([
     'portrait',
     'landscape'
@@ -19,42 +19,53 @@ var features = {
   ]),
 
   aspectRatio: PropTypes.string,
+  deviceAspectRatio: PropTypes.string,
+
+  height: stringOrNumber,
+  deviceHeight: stringOrNumber,
+
+  width: stringOrNumber,
+  deviceWidth: stringOrNumber,
+
+  color: PropTypes.bool,
+
+  colorIndex: PropTypes.bool,
+
+  monochrome: PropTypes.bool,
+  resolution: stringOrNumber
+};
+
+// media features
+var features = {
   minAspectRatio: PropTypes.string,
   maxAspectRatio: PropTypes.string,
-  deviceAspectRatio: PropTypes.string,
   minDeviceAspectRatio: PropTypes.string,
   maxDeviceAspectRatio: PropTypes.string,
 
-  height: stringOrNumber,
   minHeight: stringOrNumber,
   maxHeight: stringOrNumber,
-  deviceHeight: stringOrNumber,
   minDeviceHeight: stringOrNumber,
   maxDeviceHeight: stringOrNumber,
 
-  width: stringOrNumber,
   minWidth: stringOrNumber,
   maxWidth: stringOrNumber,
-  deviceWidth: stringOrNumber,
   minDeviceWidth: stringOrNumber,
   maxDeviceWidth: stringOrNumber,
 
-  color: PropTypes.bool,
   minColor: PropTypes.number,
   maxColor: PropTypes.number,
 
-  colorIndex: PropTypes.bool,
   minColorIndex: PropTypes.number,
   maxColorIndex: PropTypes.number,
 
-  monochrome: PropTypes.bool,
   minMonochrome: PropTypes.number,
   maxMonochrome: PropTypes.number,
 
-  resolution: stringOrNumber,
   minResolution: stringOrNumber,
   maxResolution: stringOrNumber
 };
+
+assign(features, matchers);
 
 // media types
 var types = {
@@ -77,5 +88,6 @@ assign(all, features);
 module.exports = {
   all: all,
   types: types,
+  matchers: matchers,
   features: features
 };


### PR DESCRIPTION
I was able to keep this PR much smaller than anticipated due to the `matchmedia` modules abstraction for client/server.  It just takes an optional 2nd parameter, `values`, that it uses if `window.matchMedia` can't be accessed.