### PR TITLE
Provide more flexible React peer dependency range

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "object-assign": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^0.12.0"
+    "react": "~0.12.0 || ~0.13.0"
   },
   "devDependencies": {
     "browserify": "^5.8.0",


### PR DESCRIPTION
Allows for React v0.13.x while maintaining v0.12.x support