### PR TITLE
Use matchmedia version 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "lodash.omit": "^3.0.0",
-    "matchmedia": "^0.1.1",
+    "matchmedia": "^0.1.2",
     "object-assign": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Hi,

The matchmedia package was recently updated with a bugfix I pushed that fixes a big IE10/IE11 incompatibility issue. I've updated the matchmedia dependency.

Here is the underlying fix for reference:

https://github.com/iceddev/matchmedia/commit/8fb952b4e53c772d219ac7886ad793832ae89ea4
