### PR TITLE
Use `hyphenate-style-name` module instead of React internal

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "component"
   ],
   "dependencies": {
+    "hyphenate-style-name": "^1.0.0",
     "lodash.omit": "^3.0.0",
     "matchmedia": "^0.1.1",
     "object-assign": "^2.0.0"

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
 var React = require('react');
 var omit = require('lodash.omit');
 var matchMedia = require('matchmedia');
-var hyphenate = require('react/lib/hyphenateStyleName');
+var hyphenate = require('hyphenate-style-name');
 var mediaQuery = require('./mediaQuery');
 var toQuery = require('./toQuery');
 

--- a/src/mediaQuery.js
+++ b/src/mediaQuery.js
@@ -1,4 +1,4 @@
-var PropTypes = require('react/lib/ReactPropTypes');
+var PropTypes = require('react').PropTypes;
 var assign = require('object-assign');
 
 var stringOrNumber = PropTypes.oneOfType([

--- a/src/toQuery.js
+++ b/src/toQuery.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var hyphenate = require('react/lib/hyphenateStyleName');
+var hyphenate = require('hyphenate-style-name');
 var mq = require('./mediaQuery');
 
 function negate(cond) {


### PR DESCRIPTION
In the latest react betas, Facebook has moved `hyphenateStyleName` to the `fbjs` package and is explicitly telling people not to depend on these modules if you're not Facebook. I'm slightly unsure about the best way to go, but for now I've made a super-simple module that does the same as the Facebook one.

This PR adds this module as a dependency and makes the component work on the latest React betas.

I also took the liberty of changing the proptypes require to `require('react').PropTypes` as this seems less likely to break in the future, should they decide to rearrange the internals.
